### PR TITLE
Update to HaXml 1.25.*

### DIFF
--- a/netrium-demo.cabal
+++ b/netrium-demo.cabal
@@ -43,7 +43,7 @@ library
                     containers >= 0.3 && < 1,
                     process    >= 1.0 && < 2,
                     time       >= 1.1 && < 2,
-                    HaXml      == 1.20.*
+                    HaXml      == 1.25.*
 
 executable normalise
   hs-source-dirs:   tool
@@ -53,7 +53,7 @@ executable normalise
                     process    >= 1.0 && < 2,
                     filepath   >= 1.1 && < 2,
                     directory  >= 1.0 && < 2,
-                    HaXml      == 1.20.*
+                    HaXml      == 1.25.*
 
 executable simulate
   hs-source-dirs:   tool
@@ -61,8 +61,8 @@ executable simulate
   build-depends:    netrium-demo,
                     base       >= 3.0 && < 5,
                     containers >= 0.3 && < 1,
-                    HaXml      == 1.20.*,
-                    pretty     == 1.0.*,
+                    HaXml      == 1.25.*,
+                    pretty     == 1.1.3.*,
                     directory  >= 1.0 && < 2,
                     filepath
 
@@ -74,4 +74,4 @@ executable visualise
                     directory  >= 1.0 && < 2,
                     filepath,
                     process    >= 1.0 && < 2,
-                    HaXml      == 1.20.*
+                    HaXml      == 1.25.*

--- a/src/DecisionTree.hs
+++ b/src/DecisionTree.hs
@@ -13,6 +13,7 @@ import Display
 import Prelude hiding (product, until, and)
 import Data.List hiding (and)
 import Control.Monad hiding (when)
+import Text.XML.HaXml.Namespaces (localName)
 import Text.XML.HaXml.XmlContent
 
 -- ---------------------------------------------------------------------------
@@ -402,7 +403,7 @@ instance HTypeable Party where
 instance XmlContent Party where
   parseContents = do
     e@(Elem t _ _) <- element ["Party", "Counterparty", "ThirdParty"]
-    commit $ interior e $ case t of
+    commit $ interior e $ case localName t of
       "Party"        -> return FirstParty
       "Counterparty" -> return Counterparty
       "ThirdParty"   -> liftM  ThirdParty text
@@ -420,7 +421,7 @@ instance XmlContent TradeDir where
                               ,"TradeDirPTo1","TradeDirPTo2"
                               ,"TradeDir1ToP","TradeDir2ToP"
                               ,"TradeDirPToQ","TradeDirQToP"]
-    commit $ interior e $ case t of
+    commit $ interior e $ case localName t of
       "TradeDir2To1" -> return TradeDir2To1
       "TradeDir1To2" -> return TradeDir1To2
       "TradeDirPTo1" -> liftM TradeDirPTo1 text
@@ -445,7 +446,7 @@ instance HTypeable (Blocked c) where
 instance XmlContent c => XmlContent (Blocked c) where
   parseContents = do
     e@(Elem t _ _) <- element ["BlockedOnWhen", "BlockedOnAnytime"]
-    commit $ interior e $ case t of
+    commit $ interior e $ case localName t of
       "BlockedOnWhen"    -> liftM2 BlockedOnWhen (fmap unObsCondition parseContents)
                                                  parseContents
       "BlockedOnAnytime" -> liftM4 BlockedOnAnytime parseContents

--- a/src/Interpreter.hs
+++ b/src/Interpreter.hs
@@ -19,6 +19,8 @@ import Data.Monoid
 import qualified Data.Map as Map
 import Data.Map (Map)
 import Control.Monad
+import Text.XML.HaXml.Namespaces (localName)
+import Text.XML.HaXml.Types (QName(..))
 import Text.XML.HaXml.XmlContent hiding (next)
 import XmlUtils
 import Control.Exception (assert)
@@ -377,21 +379,21 @@ instance HTypeable Output where
 instance XmlContent Output where
     parseContents = do
       e@(Elem t _ _) <- element ["Trade","OptionUntil","OptionForever"]
-      commit $ interior e $ case t of
+      commit $ interior e $ case localName t of
         "Trade"         -> liftM4 Trade parseContents parseContents
                                         parseContents parseContents
-        "OptionUntil"   -> liftM2 OptionUntil   (attrStr "choiceid" e) parseContents
-        "OptionForever" -> liftM  OptionForever (attrStr "choiceid" e)
+        "OptionUntil"   -> liftM2 OptionUntil   (attrStr (N "choiceid") e) parseContents
+        "OptionForever" -> liftM  OptionForever (attrStr (N "choiceid") e)
 
     toContents (Trade p p' sf t)       = [mkElemC "Trade" (toContents p
                                                           ++ toContents p'
                                                           ++ toContents sf
                                                           ++ toContents t)]
-    toContents (OptionUntil cid time') = [mkElemAC "OptionUntil"
-                                                   [("choiceid", str2attr cid)]
+    toContents (OptionUntil cid time') = [mkElemAC (N "OptionUntil")
+                                                   [(N "choiceid", str2attr cid)]
                                                    (toContents time')]
-    toContents (OptionForever cid)     = [mkElemAC "OptionForever"
-                                                   [("choiceid", str2attr cid)] []]
+    toContents (OptionForever cid)     = [mkElemAC (N "OptionForever")
+                                                   [(N "choiceid", str2attr cid)] []]
 
 
 instance HTypeable StopReason where
@@ -402,15 +404,15 @@ instance XmlContent StopReason where
       e@(Elem t _ _) <- element ["Finished", "StoppedTime", "StoppedWait","WaitForever"
                                 ,"ChoiceRequired"
                                 ,"ObservationMissing","ObservationExhausted"]
-      commit $ interior e $ case t of
+      commit $ interior e $ case localName t of
         "Finished"       -> return Finished
         "StoppedTime"    -> return StoppedTime
         "StoppedWait"    -> return StoppedWait
         "WaitForever"    -> return WaitForever
         "ChoiceRequired" -> liftM2 ChoiceRequired parseContents
-                                                  (attrStr "choiceid" e)
-        "ObservationMissing"   -> liftM ObservationMissing   (attrStr "var" e)
-        "ObservationExhausted" -> liftM ObservationExhausted (attrStr "var" e)
+                                                  (attrStr (N "choiceid") e)
+        "ObservationMissing"   -> liftM ObservationMissing   (attrStr (N "var") e)
+        "ObservationExhausted" -> liftM ObservationExhausted (attrStr (N "var") e)
 
     toContents Finished    = [mkElemC "Finished"    []]
     toContents StoppedTime = [mkElemC "StoppedTime" []]
@@ -418,12 +420,12 @@ instance XmlContent StopReason where
     toContents WaitForever = [mkElemC "WaitForever" []]
 
     toContents (ChoiceRequired party choiceid) =
-        [mkElemAC "ChoiceRequired" [("choiceid", str2attr choiceid)]
-                                   (toContents party)]
+        [mkElemAC (N "ChoiceRequired") [(N "choiceid", str2attr choiceid)]
+                                       (toContents party)]
     toContents (ObservationExhausted varname) =
-        [mkElemAC "ObservationExhausted" [("var", str2attr varname)] []]
+        [mkElemAC (N "ObservationExhausted") [(N "var", str2attr varname)] []]
     toContents (ObservationMissing   varname) =
-        [mkElemAC "ObservationMissing" [("var", str2attr varname)] []]
+        [mkElemAC (N "ObservationMissing") [(N "var", str2attr varname)] []]
 
 
 instance HTypeable StopWait where
@@ -432,7 +434,7 @@ instance HTypeable StopWait where
 instance XmlContent StopWait where
   parseContents = (do
     e@(Elem t _ _) <- element ["StopFirstWait", "StopNextWait"]
-    commit $ interior e $ case t of
+    commit $ interior e $ case localName t of
       "StopFirstWait" -> return StopFirstWait
       "StopNextWait"  -> return StopNextWait)
     `onFail` return NoStop

--- a/src/Observable.hs
+++ b/src/Observable.hs
@@ -47,6 +47,7 @@ import Data.List (minimumBy)
 import Data.Ord (comparing)
 import Control.Monad
 import Text.Show.Functions ()
+import Text.XML.HaXml.Namespaces (localName)
 import Text.XML.HaXml.XmlContent
   (XMLParser(), Element(..), Content(), element, interior, text, toText, mkElemC)
 
@@ -728,7 +729,7 @@ parseObsReal = do
   e@(Elem t _ _) <- element ["Const","Var","NamedVal","IfThen"
                             ,"Neg","Abs","Sqrt","Exp","Log","Sin","Cos","Asin","Acos","Atan","Sinh","Cosh","Asinh","Acosh","Atanh","Add","Sub","Mul","Div","Min","Max"]
 
-  case t of
+  case localName t of
     "Const"    -> interior e $ liftM Const readText
     "Var"      -> interior e $ liftM Var text
     "NamedVal" -> interior e $ liftM NamedVal text
@@ -764,7 +765,7 @@ parseObsCond = do
   e@(Elem t _ _) <- element ["Const","NamedCond","At", "After","Before","IfThen"
                             ,"Not","And","Or","Eq","Gt","Gte","Lt","Lte"]
 
-  case t of
+  case localName t of
     "Const"     -> interior e $ liftM Const readText
     "NamedCond" -> interior e $ liftM NamedCond text
 

--- a/src/ObservableDB.hs
+++ b/src/ObservableDB.hs
@@ -4,6 +4,8 @@
 module ObservableDB where
 
 import Control.Monad              (liftM, liftM2)
+import Text.XML.HaXml.Namespaces  (localName)
+import Text.XML.HaXml.Types       (QName(..))
 import Text.XML.HaXml.XmlContent
 
 import XmlUtils
@@ -31,11 +33,11 @@ instance HTypeable ObservableDecl where
 instance XmlContent ObservableDecl where
   parseContents = do
     e@(Elem t _ _) <- element ["ObservableDecl"]
-    commit $ interior e $ case t of
-      "ObservableDecl" -> liftM2 ObservableDecl (attrStr "name" e) parseContents
+    commit $ interior e $ case localName t of
+      "ObservableDecl" -> liftM2 ObservableDecl (attrStr (N "name") e) parseContents
 
   toContents (ObservableDecl n t) =
-    [mkElemAC "ObservableDecl" [("name", str2attr n)] (toContents t)]
+    [mkElemAC (N "ObservableDecl") [(N "name", str2attr n)] (toContents t)]
 
 instance HTypeable ObservableType where
   toHType _ = Defined "ObservableType" [] []
@@ -43,7 +45,7 @@ instance HTypeable ObservableType where
 instance XmlContent ObservableType where
   parseContents = do
     e@(Elem t _ _) <- element ["Double", "Bool"]
-    commit $ interior e $ case t of
+    commit $ interior e $ case localName t of
       "Double" -> return Double
       "Bool"   -> return Bool
 

--- a/src/Observations.hs
+++ b/src/Observations.hs
@@ -16,6 +16,8 @@ import qualified Data.Map as Map
 import Data.Map (Map)
 import Data.Monoid
 import Data.Function
+import Text.XML.HaXml.Namespaces (localName)
+import Text.XML.HaXml.Types (QName(..))
 import Text.XML.HaXml.XmlContent
 
 
@@ -178,22 +180,22 @@ instance HTypeable ObservationSeries where
 instance XmlContent ObservationSeries where
   parseContents = do
     e@(Elem t _ _) <- element ["ObservationSeries"]
-    commit $ interior e $ case t of
+    commit $ interior e $ case localName t of
       "ObservationSeries" -> do
-        seriesType <- attrRead "type" e
-        seriesVar  <- attrStr  "var"  e
+        seriesType <- attrRead (N "type") e
+        seriesVar  <- attrStr  (N "var")  e
         case seriesType of
           Double -> liftM (ObservationsSeriesDouble seriesVar) parseContents
           Bool   -> liftM (ObservationsSeriesBool   seriesVar) parseContents
 
   toContents (ObservationsSeriesBool var ts) =
-    [mkElemAC "ObservationSeries" [("type", str2attr "Bool")
-                                  ,("var",  str2attr var)]
-                                  (toContents ts)]
+    [mkElemAC (N "ObservationSeries") [(N "type", str2attr "Bool")
+                                      ,(N "var",  str2attr var)]
+                                      (toContents ts)]
   toContents (ObservationsSeriesDouble var ts) =
-    [mkElemAC "ObservationSeries" [("type", str2attr "Double")
-                                  ,("var",  str2attr var)]
-                                  (toContents ts)]
+    [mkElemAC (N "ObservationSeries") [(N "type", str2attr "Double")
+                                      ,(N "var",  str2attr var)]
+                                      (toContents ts)]
 
 
 data ChoiceSeries = ChoiceSeries (XMLTimedEvents Choice)
@@ -209,7 +211,7 @@ instance HTypeable Choice where
 instance XmlContent ChoiceSeries where
   parseContents = do
     e@(Elem t _ _) <- element ["Choices"]
-    commit $ interior e $ case t of
+    commit $ interior e $ case localName t of
       "Choices" -> liftM ChoiceSeries parseContents
 
   toContents (ChoiceSeries cs) = [mkElemC "Choices" (toContents cs)]
@@ -217,18 +219,18 @@ instance XmlContent ChoiceSeries where
 instance XmlContent Choice where
   parseContents = do
     e@(Elem t _ _) <- element ["Choice"]
-    commit $ interior e $ case t of
+    commit $ interior e $ case localName t of
       "Choice" -> do
-        cid <- attrStr "choiceid" e
+        cid <- attrStr (N "choiceid") e
         content <- parseContents
         case content of
           Nothing -> return (AnytimeChoice cid)
           Just m  -> return (OrChoice cid m)
 
   toContents (OrChoice cid m)    =
-    [mkElemAC "Choice" [("choiceid", str2attr cid)] (toContents m)]
+    [mkElemAC (N "Choice") [(N "choiceid", str2attr cid)] (toContents m)]
   toContents (AnytimeChoice cid) =
-    [mkElemAC "Choice" [("choiceid", str2attr cid)] []]
+    [mkElemAC (N "Choice") [(N "choiceid", str2attr cid)] []]
 
 
 data Timed a = Timed Time a
@@ -240,7 +242,7 @@ instance HTypeable SeriesEnd where
 instance XmlContent SeriesEnd where
   parseContents = do
     e@(Elem t _ _) <- element ["SeriesUnbounded", "SeriesEnds"]
-    commit $ interior e $ case t of
+    commit $ interior e $ case localName  t of
       "SeriesUnbounded" -> return Unbounded
       "SeriesEnds"      -> liftM Bounded parseContents
 

--- a/src/UnitsDB.hs
+++ b/src/UnitsDB.hs
@@ -4,6 +4,8 @@
 module UnitsDB where
 
 import Control.Monad              (liftM, liftM2)
+import Text.XML.HaXml.Namespaces  (localName)
+import Text.XML.HaXml.Types       (QName(..))
 import Text.XML.HaXml.XmlContent
 
 import XmlUtils
@@ -35,23 +37,23 @@ instance XmlContent UnitDecl where
     e@(Elem t _ _) <- element ["CommodityDecl", "CashFlowTypeDecl",
                                "UnitDecl",
                                "LocationDecl", "CurrencyDecl"]
-    commit $ interior e $ case t of
-      "CashFlowTypeDecl"  -> liftM CashFlowTypeDecl  (attrStr "name" e)
-      "CommodityDecl"     -> liftM CommodityDecl     (attrStr "name" e)
-      "UnitDecl"          -> liftM UnitDecl          (attrStr "name" e)
-      "LocationDecl"      -> liftM LocationDecl      (attrStr "name" e)
-      "CurrencyDecl"      -> liftM CurrencyDecl      (attrStr "name" e)
+    commit $ interior e $ case localName t of
+      "CashFlowTypeDecl"  -> liftM CashFlowTypeDecl  (attrStr (N "name") e)
+      "CommodityDecl"     -> liftM CommodityDecl     (attrStr (N "name") e)
+      "UnitDecl"          -> liftM UnitDecl          (attrStr (N "name") e)
+      "LocationDecl"      -> liftM LocationDecl      (attrStr (N "name") e)
+      "CurrencyDecl"      -> liftM CurrencyDecl      (attrStr (N "name") e)
 
-  toContents (CommodityDecl n ) =
-    [mkElemAC "CommodityDecl" [("name", str2attr n)] []]
-  toContents (CashFlowTypeDecl n ) =
-    [mkElemAC "CashFlowTypeDecl" [("name", str2attr n)] []]
-  toContents (UnitDecl n ) =
-    [mkElemAC "UnitDecl" [("name", str2attr n)] []]
-  toContents (LocationDecl n ) =
-    [mkElemAC "LocationDecl" [("name", str2attr n)] []]
-  toContents (CurrencyDecl n ) =
-    [mkElemAC "CurrencyDecl" [("name", str2attr n)] []]
+  toContents (CommodityDecl n) =
+    [mkElemAC (N "CommodityDecl") [(N "name", str2attr n)] []]
+  toContents (CashFlowTypeDecl n) =
+    [mkElemAC (N "CashFlowTypeDecl") [(N "name", str2attr n)] []]
+  toContents (UnitDecl n) =
+    [mkElemAC (N "UnitDecl") [(N "name", str2attr n)] []]
+  toContents (LocationDecl n) =
+    [mkElemAC (N "LocationDecl") [(N "name", str2attr n)] []]
+  toContents (CurrencyDecl n) =
+    [mkElemAC (N "CurrencyDecl") [(N "name", str2attr n)] []]
 
 
 compileUnitsDB :: UnitsDB -> String

--- a/src/XmlUtils.hs
+++ b/src/XmlUtils.hs
@@ -4,19 +4,20 @@
 {-# OPTIONS_HADDOCK hide #-}
 module XmlUtils where
 
+import Text.XML.HaXml.Namespaces (localName)
 import Text.XML.HaXml.XmlContent
 import Data.Time
 
 attrStr n (Elem _ as _) =
     case lookup n as of
-      Nothing -> fail ("expected attribute " ++ n)
+      Nothing -> fail ("expected attribute " ++ localName n)
       Just av -> return (attr2str av)
 
 attrRead n e = do
     str <- attrStr n e
     case reads str of
       [(v,_)] -> return v
-      _       -> fail $ "cannot parse attribute " ++ n ++ ": " ++ str
+      _       -> fail $ "cannot parse attribute " ++ localName n ++ ": " ++ str
 
 mkElemAC x as cs = CElem (Elem x as cs) ()
 
@@ -31,7 +32,7 @@ readText = do
 instance XmlContent Bool where
   parseContents = do
     e@(Elem t _ _) <- element ["True", "False"]
-    commit $ interior e $ case t of
+    commit $ interior e $ case localName t of
       "True"  -> return True
       "False" -> return False
 

--- a/tool/Simulate.hs
+++ b/tool/Simulate.hs
@@ -19,6 +19,7 @@ import System.Exit
 import System.Console.GetOpt
 import System.FilePath
 
+import Text.XML.HaXml.Namespaces (localName)
 import Text.XML.HaXml.Types
 import Text.XML.HaXml.Pretty (document)
 import Text.XML.HaXml.XmlContent
@@ -149,7 +150,7 @@ renderContractRunXml (SimOutputs _ outs stopReason stopTime residualContract sim
 
   where
     prolog = Prolog (Just (XMLDecl "1.0" Nothing Nothing)) [] Nothing []
-    body   = Elem "SimulationResult" [] $
+    body   = Elem (N "SimulationResult") [] $
                      toContents (fromTimedEvents outs)
                   ++ toContents stopReason
                   ++ toContents stopTime
@@ -169,7 +170,7 @@ instance HTypeable SimulationInputs where
 instance XmlContent SimulationInputs where
   parseContents = do
     e@(Elem t _ _) <- element ["SimulationInputs"]
-    commit $ interior e $ case t of
+    commit $ interior e $ case localName t of
       "SimulationInputs" -> do
         startTime    <- parseContents
         mStopTime    <- parseContents


### PR DESCRIPTION
This patch updates Netrium to the current version of HaXml. This version bump precipitated several fairly mechanical code changes, as HaXml now supports namespaces. Many `String`s had to become `QName`s and vice versa.