### PR TITLE
Fix DecisionTree haddock errors

### DIFF
--- a/src/DecisionTree.hs
+++ b/src/DecisionTree.hs
@@ -59,15 +59,17 @@ decisionTree t c = unfoldDecisionTree
 -- * Basic step
 -- ---------------------------------------------------------------------------
 
-data ProcessState = PSt Time                   -- ^ current time
-                        [Blocked ThreadState]  -- ^ blocked
-                        [ThreadState]          -- ^ runnable
+-- | Current time, blocked, and runnable 'ThreadState's
+data ProcessState = PSt Time                   -- current time
+                        [Blocked ThreadState]  -- blocked
+                        [ThreadState]          -- runnable
   deriving (Show, Eq)
 
-data ThreadState  = TSt Contract          -- ^ remaining contract
-                        [Obs Bool]        -- ^ 'until' conditions
-                        ScaleFactor       -- ^ inherited scaling
-                        TradeDir          -- ^ direction of trade
+-- | Remaining contract, 'until' conditions, inherited scaling, and direction of trade
+data ThreadState  = TSt Contract          -- remaining contract
+                        [Obs Bool]        -- 'until' conditions
+                        ScaleFactor       -- inherited scaling
+                        TradeDir          -- direction of trade
   deriving (Show, Eq)
 
 data Blocked c =


### PR DESCRIPTION
Haddock doesn't seem to support support this sort of caret-commenting between the fields of a sum type. My guess is that this documentation pattern was supported (or at least accepted) in older versions of haddock, but nowadays it produces an error.